### PR TITLE
fix: body_might_complete_normally_nullable

### DIFF
--- a/jinhe_client/lib/settings/settings_logic.dart
+++ b/jinhe_client/lib/settings/settings_logic.dart
@@ -82,6 +82,7 @@ class SettingsLogic extends GetxController with L {
     } catch (e) {
       l.error(e);
       Get.snackbar('获取最新版本失败', e.toString());
+      return null;
     }
   }
 


### PR DESCRIPTION
This function has a nullable return type of 'FutureOr<String?>', but ends without returning a value • lib/settings/settings_logic.dart:74:19 • body_might_complete_normally_nullable